### PR TITLE
Replace origin URL with a CrawlJob

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,6 @@ subprojects {
             testCompile "org.junit.jupiter:junit-jupiter-api:5.0.0"
             testRuntime "org.junit.jupiter:junit-jupiter-engine:5.0.0"
             testCompile 'org.assertj:assertj-core:3.8.0'
-            testCompile 'com.github.jlink:jqwik:0.5.0'
         }
     }
 

--- a/cli/src/main/java/io/lepo/lukki/cli/Main.java
+++ b/cli/src/main/java/io/lepo/lukki/cli/Main.java
@@ -1,6 +1,7 @@
 package io.lepo.lukki.cli;
 
 import io.lepo.lukki.core.CrawlEngine;
+import io.lepo.lukki.core.CrawlJob;
 import io.lepo.lukki.core.Filters;
 import io.lepo.lukki.core.Script;
 import io.lepo.lukki.core.ScriptRegistry;
@@ -12,7 +13,7 @@ import java.util.Map;
 
 public class Main {
 
-  public static void main(String[] args) {
+  public static void main(String[] args) throws Exception {
     Map<String, Script<?>> scripts = new HashMap<>();
     scripts.put(Html.mimeType, Html.script(new ArrayList<>()));
     ScriptRegistry scriptRegistry = ScriptRegistry.lenient(scripts);
@@ -22,6 +23,6 @@ public class Main {
         scriptRegistry,
         new Filters(Filters.LinkFilter.skipNone, Filters.DocumentFilter.skipForeignHost)
     );
-    crawler.run(args[0]);
+    crawler.run(CrawlJob.withHostsStartingWithUrlHost(args[0]));
   }
 }

--- a/core/src/main/java/io/lepo/lukki/core/CrawlContext.java
+++ b/core/src/main/java/io/lepo/lukki/core/CrawlContext.java
@@ -4,25 +4,25 @@ import java.nio.charset.Charset;
 
 public final class CrawlContext {
 
-  private final String originUrl;
+  private final CrawlJob job;
   private final String url;
   private final String mimeType;
   private final Charset charset;
 
   public CrawlContext(
-      String originUrl,
+      CrawlJob job,
       String url,
       String mimeType,
       Charset charset
   ) {
-    this.originUrl = originUrl;
+    this.job = job;
     this.url = url;
     this.mimeType = mimeType;
     this.charset = charset;
   }
 
-  public String getOriginUrl() {
-    return originUrl;
+  public CrawlJob getJob() {
+    return job;
   }
 
   public String getUrl() {
@@ -40,7 +40,7 @@ public final class CrawlContext {
   @Override
   public String toString() {
     return "CrawlContext{"
-        + "originUrl='" + originUrl + '\''
+        + "job='" + job.toString() + '\''
         + ", url='" + url + '\''
         + ", mimeType='" + mimeType + '\''
         + '}';

--- a/core/src/main/java/io/lepo/lukki/core/CrawlJob.java
+++ b/core/src/main/java/io/lepo/lukki/core/CrawlJob.java
@@ -1,0 +1,65 @@
+package io.lepo.lukki.core;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.Set;
+
+public class CrawlJob {
+
+  private final String url;
+  private final Set<String> siteHosts;
+  private final Set<String> siteHostPrefixes;
+
+  public CrawlJob(
+      String url,
+      Set<String> siteHosts,
+      Set<String> siteHostPrefixes
+  ) {
+    this.url = url;
+    this.siteHosts = Collections.unmodifiableSet(siteHosts);
+    this.siteHostPrefixes = Collections.unmodifiableSet(siteHostPrefixes);
+  }
+
+  public String getUrl() {
+    return url;
+  }
+
+  public Set<String> getSiteHosts() {
+    return siteHosts;
+  }
+
+  public Set<String> getSiteHostPrefixes() {
+    return siteHostPrefixes;
+  }
+
+  public boolean isSiteHost(String host) {
+    return siteHosts.contains(host) || siteHostPrefixes.stream().anyMatch(host::endsWith);
+  }
+
+  public boolean isSiteUrl(String url) {
+    try {
+      String host = new URL(url).getHost();
+      return isSiteHost(host);
+    } catch (MalformedURLException ex) {
+      return false;
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "CrawlJob{"
+        + "url='" + url + '\''
+        + '}';
+  }
+
+  public static CrawlJob withOnlyUrlHost(String url) throws MalformedURLException {
+    String host = new URL(url).getHost();
+    return new CrawlJob(url, Collections.singleton(host), Collections.emptySet());
+  }
+
+  public static CrawlJob withHostsStartingWithUrlHost(String url) throws MalformedURLException {
+    String host = new URL(url).getHost();
+    return new CrawlJob(url, Collections.singleton(host), Collections.singleton(host));
+  }
+}

--- a/core/src/main/java/io/lepo/lukki/core/Filters.java
+++ b/core/src/main/java/io/lepo/lukki/core/Filters.java
@@ -1,35 +1,22 @@
 package io.lepo.lukki.core;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 
 public final class Filters {
 
-  private static boolean hasSameHost(String url1, String url2) {
-    try {
-      String host1 = new URL(url1).getHost();
-      String host2 = new URL(url2).getHost();
-      return host1.equals(host2);
-    } catch (MalformedURLException ex) {
-      throw new RuntimeException(ex);
-    }
-  }
-
   public interface LinkFilter extends BiPredicate<CrawlContext, String> {
 
     LinkFilter skipNone = (context, link) -> true;
     LinkFilter skipAll = (context, link) -> false;
-    LinkFilter skipForeignHost = (context, link) -> hasSameHost(context.getOriginUrl(), link);
+    LinkFilter skipForeignHost = (context, link) -> context.getJob().isSiteUrl(link);
   }
 
   public interface DocumentFilter extends Predicate<CrawlContext> {
 
     DocumentFilter skipNone = (context) -> true;
     DocumentFilter skipAll = (context) -> false;
-    DocumentFilter skipForeignHost = (context) ->
-        hasSameHost(context.getOriginUrl(), context.getUrl());
+    DocumentFilter skipForeignHost = (context) -> context.getJob().isSiteUrl(context.getUrl());
   }
 
   private final LinkFilter linkFilter;

--- a/core/src/test/java/io/lepo/lukki/core/FiltersTest.java
+++ b/core/src/test/java/io/lepo/lukki/core/FiltersTest.java
@@ -1,9 +1,0 @@
-package io.lepo.lukki.core;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import org.junit.jupiter.api.Test;
-
-class FiltersTest {
-
-}

--- a/core/src/test/java/io/lepo/lukki/core/FiltersTests.java
+++ b/core/src/test/java/io/lepo/lukki/core/FiltersTests.java
@@ -1,0 +1,80 @@
+package io.lepo.lukki.core;
+
+import io.lepo.lukki.core.Filters.DocumentFilter;
+import io.lepo.lukki.core.Filters.LinkFilter;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.assertj.core.api.Assertions;
+
+class FiltersTests {
+
+  private static final String[][] linksShouldNotSkip = {
+      {"https://lepo.io/", "https://lepo.io/index.html"},
+      {"https://lepo.io/", "https://lepo.io/team/index.html"},
+      {"https://lepo.io/", "http://lepo.io/"},
+      {"https://lepo.io/", "http://lepo.io/helloworld.html"},
+      {"https://lepo.io/", "http://www.lepo.io/helloworld.html"}
+  };
+
+  private static final String[][] linksShouldSkip = {
+      {"https://sub.lepo.io/", "https://lepo.io/"},
+      {"https://lepo.io/", "https://google.com/"}
+  };
+
+
+  @Test
+  @DisplayName("LinkFilter.skipForeignHost")
+  void skipForeignHostLinkFilter() throws Exception {
+    for (String[] links : linksShouldNotSkip) {
+      CrawlJob job = CrawlJob.withHostsStartingWithUrlHost(links[0]);
+      CrawlContext context = createContext(job, links[0]);
+
+      Assertions
+          .assertThat(LinkFilter.skipForeignHost.test(context, links[1]))
+          .as("no skip: %s - %s", links[0], links[1])
+          .isTrue();
+    }
+
+    for (String[] links : linksShouldSkip) {
+      CrawlJob job = CrawlJob.withHostsStartingWithUrlHost(links[0]);
+      CrawlContext context = createContext(job, links[0]);
+
+      Assertions
+          .assertThat(LinkFilter.skipForeignHost.test(context, links[1]))
+          .as("skip: %s - %s", links[0], links[1])
+          .isFalse();
+    }
+  }
+
+  @Test
+  @DisplayName("DocumentFilter.skipForeignHost")
+  void skipForeignHostDocumentFilter() throws Exception {
+    for (String[] links : linksShouldNotSkip) {
+      CrawlJob job = CrawlJob.withHostsStartingWithUrlHost(links[0]);
+      CrawlContext context = createContext(job, links[1]);
+
+      Assertions
+          .assertThat(DocumentFilter.skipForeignHost.test(context))
+          .as("no skip: %s - %s", links[0], links[1])
+          .isTrue();
+    }
+
+    for (String[] links : linksShouldSkip) {
+      CrawlJob job = CrawlJob.withHostsStartingWithUrlHost(links[0]);
+      CrawlContext context = createContext(job, links[1]);
+
+      Assertions
+          .assertThat(DocumentFilter.skipForeignHost.test(context))
+          .as("skip: %s - %s", links[0], links[1])
+          .isFalse();
+    }
+  }
+
+  private CrawlContext createContext(CrawlJob job, String url) {
+    return new CrawlContext(
+        job, url,
+        "text/html", StandardCharsets.UTF_8
+    );
+  }
+}


### PR DESCRIPTION
Crawls are kicked of with a crawl job description. This includes the URL
the engine starts crawling from and information about which hosts are
considered part of the site that's being crawled. All of this is made
available in the CrawlContext, thus CrawlJob contents can also be used
for filtering crawled docs and links.