### PR TITLE
Test and report sub-commands

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -22,7 +22,7 @@ var (
 	}
 )
 
-type Config struct {
+type CrawlConfig struct {
 	URLs            []string  `json:"urls"`
 	HomeHosts       []string  `json:"homeHosts"`
 	UserAgent       string    `json:"userAgent"`
@@ -36,19 +36,19 @@ type Element struct {
 	Attribute string `json:"attribute"`
 }
 
-func (c *Config) FromJSON(input io.Reader) error {
+func (c *CrawlConfig) FromJSON(input io.Reader) error {
 	if err := json.NewDecoder(input).Decode(c); err != nil {
 		return err
 	}
 	return c.Init()
 }
 
-func (c *Config) FromSTDIN() error {
+func (c *CrawlConfig) FromSTDIN() error {
 	reader := bufio.NewReader(os.Stdin)
 	return c.FromJSON(reader)
 }
 
-func (c *Config) FromFile(filename string) error {
+func (c *CrawlConfig) FromFile(filename string) error {
 	file, err := os.Open(filename)
 	if err != nil {
 		return err
@@ -62,7 +62,7 @@ func (c *Config) FromFile(filename string) error {
 	return c.FromJSON(bufio.NewReader(file))
 }
 
-func (c *Config) Init() (err error) {
+func (c *CrawlConfig) Init() (err error) {
 	if len(c.Elements) == 0 {
 		c.Elements = defaultElements
 	}
@@ -91,7 +91,7 @@ func extractHosts(urls []string) ([]string, error) {
 	return hostsSlice, nil
 }
 
-func (c *Config) HomeHostsMap() map[string]bool {
+func (c *CrawlConfig) HomeHostsMap() map[string]bool {
 	hosts := make(map[string]bool, len(c.HomeHosts))
 	for _, host := range c.HomeHosts {
 		hosts[host] = true

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -8,7 +8,7 @@ import (
 func TestConfigInit(t *testing.T) {
 	a := assert.New(t)
 
-	conf := Config{URLs: []string{"http://localhost:1313/", "https://lepo.group/"}}
+	conf := CrawlConfig{URLs: []string{"http://localhost:1313/", "https://lepo.group/"}}
 	err := conf.Init()
 
 	a.NoError(err)

--- a/crawler/crawl.go
+++ b/crawler/crawl.go
@@ -9,7 +9,7 @@ import (
 	"github.com/gocolly/colly"
 )
 
-func crawl(conf *config.Config, events chan interface{}) error {
+func crawl(conf *config.CrawlConfig, events chan interface{}) error {
 	collector := colly.NewCollector()
 	collector.IgnoreRobotsTxt = conf.IgnoreRobotsTxt
 	collector.UserAgent = conf.UserAgent

--- a/crawler/exec.go
+++ b/crawler/exec.go
@@ -5,7 +5,7 @@ import (
 	"github.com/Lepovirta/lukki/report"
 )
 
-func Execute(conf *config.Config) (*report.Report, error) {
+func Execute(conf *config.CrawlConfig) (*report.Report, error) {
 	events := make(chan interface{}, 1000)
 	collector := newCollector()
 	asyncCollector := newAsyncCollector(collector, events)

--- a/format/format.go
+++ b/format/format.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	ErrUnknownType = errors.New("Unknown format type")
+	ErrUnknownType = errors.New("unknown format type")
 )
 
 func ByType(t string, report *report.Report, output io.Writer) error {

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/stretchr/objx v0.1.1 // indirect
 	github.com/stretchr/testify v1.3.0
 	github.com/temoto/robotstxt v0.0.0-20180810133444-97ee4a9ee6ea // indirect
+	github.com/tucnak/climax v0.0.0-20180716104603-da4c02f3b1f8
 	golang.org/x/net v0.0.0-20190403144856-b630fd6fe46b // indirect
 	golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6 // indirect
 	google.golang.org/appengine v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/temoto/robotstxt v0.0.0-20180810133444-97ee4a9ee6ea h1:hH8P1IiDpzRU6ZDbDh/RDnVuezi2oOXJpApa06M0zyI=
 github.com/temoto/robotstxt v0.0.0-20180810133444-97ee4a9ee6ea/go.mod h1:aOux3gHPCftJ3KHq6Pz/AlDjYJ7Y+yKfm1gU/3B0u04=
+github.com/tucnak/climax v0.0.0-20180716104603-da4c02f3b1f8 h1:RcJG0MV43QdBqPJq6ChadXDSGCyulb4jCrSTKEMX6fk=
+github.com/tucnak/climax v0.0.0-20180716104603-da4c02f3b1f8/go.mod h1:aN8AHR3MaHF61SaAxoSwsOS/AjZrRJeYAlrs4mg3ugk=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/integration_test.go
+++ b/integration_test.go
@@ -49,8 +49,8 @@ func serverUrl(path string) string {
 	return fmt.Sprintf("http://%s%s", serverAddress, path)
 }
 
-func createConfig(path string) (*config.Config, error) {
-	c := config.Config{
+func createConfig(path string) (*config.CrawlConfig, error) {
+	c := config.CrawlConfig{
 		URLs: []string{serverUrl(path)},
 	}
 	return &c, c.Init()
@@ -76,7 +76,7 @@ func TestWorkingSite(t *testing.T) {
 	assertMatchesResources(
 		t,
 		r.Resources,
-		[]func(*report.Resource)bool{
+		[]func(*report.Resource) bool{
 			matchResource("index.html", 200),
 			matchResource("test1.html", 200),
 			matchResource("test2.html", 200),
@@ -103,7 +103,7 @@ func TestFailingSite(t *testing.T) {
 	assertMatchesResources(
 		t,
 		r.Resources,
-		[]func(*report.Resource)bool{
+		[]func(*report.Resource) bool{
 			matchResource("fail.html", 200),
 			matchResource("test1.html", 200),
 			matchResource("test2.html", 200),
@@ -115,7 +115,7 @@ func TestFailingSite(t *testing.T) {
 	)
 }
 
-func matchResource(path string, statusCode int) func(*report.Resource)bool {
+func matchResource(path string, statusCode int) func(*report.Resource) bool {
 	return func(r *report.Resource) bool {
 		return r.URL == serverUrl(path) && r.StatusCode == statusCode
 	}

--- a/lukki.go
+++ b/lukki.go
@@ -2,76 +2,208 @@ package main
 
 import (
 	"bufio"
-	"flag"
+	"fmt"
 	"github.com/Lepovirta/lukki/config"
 	"github.com/Lepovirta/lukki/crawler"
 	"github.com/Lepovirta/lukki/format"
 	"github.com/Lepovirta/lukki/internal/buildinfo"
 	"github.com/Lepovirta/lukki/report"
+	"github.com/tucnak/climax"
 	"io"
 	"log"
 	"os"
 )
 
-var (
-	configPath   = flag.String("config", "STDIN", "File to read configuration from")
-	outputPath   = flag.String("output", "STDOUT", "File to write configuration to")
-	reportFormat = flag.String("format", "ascii", "Format of the report")
-	printVersion = flag.Bool("version", false, "Print version information")
-)
-
 func main() {
-	success, err := mainWithResult()
+	app := climax.New("lukki")
+	app.Brief = "Lukki - A website tester"
+	app.Version = buildinfo.Version
+	app.AddCommand(climax.Command{
+		Name:  "test",
+		Brief: "Test a website",
+		Help:  `Test a website by crawling the website as specified in the given configuration file.`,
+		Flags: []climax.Flag{
+			{
+				Name:     "config",
+				Short:    "c",
+				Help:     "File to read the configuration from (default: STDIN)",
+				Usage:    `--config=config.json`,
+				Variable: true,
+			},
+			{
+				Name:     "output",
+				Short:    "o",
+				Usage:    `--output=report.json`,
+				Help:     "File to write the output to (default: STDOUT)",
+				Variable: true,
+			},
+			{
+				Name:     "format",
+				Short:    "f",
+				Usage:    `--format=ascii`,
+				Help:     "Report format (choices: json, ascii) (default: json)",
+				Variable: true,
+			},
+		},
+		Examples: []climax.Example{
+			{
+				Usecase:     "--config=config.json --output=report.txt --format=ascii",
+				Description: `Read config from "config.json", write report to "report.txt" in ASCII format`,
+			},
+			{
+				Usecase:     "--format=ascii",
+				Description: `Read config from STDIN, write report to STDOUT in ASCII format`,
+			},
+		},
+		Handle: testWebsite,
+	})
+	app.AddCommand(climax.Command{
+		Name:  "format",
+		Brief: "Format a JSON report",
+		Help:  `Convert a JSON report into another format`,
+		Flags: []climax.Flag{
+			{
+				Name:     "input",
+				Short:    "i",
+				Help:     "File to read the report from (default: STDIN)",
+				Usage:    `--input=input.json`,
+				Variable: true,
+			},
+			{
+				Name:     "output",
+				Short:    "o",
+				Usage:    `--output=report.txt`,
+				Help:     "File to write the output to (default: STDOUT)",
+				Variable: true,
+			},
+			{
+				Name:     "format",
+				Short:    "f",
+				Usage:    `--format=ascii`,
+				Help:     fmt.Sprintf("Report format (choices: json, ascii) (default: ascii)"),
+				Variable: true,
+			},
+		},
+		Examples: []climax.Example{
+			{
+				Usecase:     "--input=report.json --output=report.txt --format=ascii",
+				Description: `Read report from "report.json", write report to "report.txt" in ASCII format`,
+			},
+			{
+				Usecase:     "--format=ascii",
+				Description: `Read report from STDIN, write report to STDOUT in ASCII format`,
+			},
+		},
+		Handle: formatReport,
+	})
+	app.AddCommand(climax.Command{
+		Name:   "version",
+		Brief:  "Print version",
+		Handle: printVersion,
+	})
+	os.Exit(app.Run())
+}
+
+func printVersion(_ climax.Context) int {
+	buildinfo.PrintVersion()
+	return 0
+}
+
+func testWebsite(ctx climax.Context) int {
+	var conf config.CrawlConfig
+	configPath, _ := ctx.Get("config")
+	outputPath, _ := ctx.Get("output")
+	reportFormat, ok := ctx.Get("format")
+	if !ok {
+		reportFormat = "json"
+	}
+
+	if err := readConfig(&conf, configPath); err != nil {
+		log.Panic(err)
+	}
+	r, err := crawler.Execute(&conf)
 	if err != nil {
 		log.Panic(err)
 	}
-	if !success {
-		os.Exit(1)
+	if err := writeReport(r, outputPath, reportFormat); err != nil {
+		log.Printf("failed to write report: %s", err)
+		return 1
 	}
+
+	if r.IsSuccessful() {
+		return 0
+	}
+	return 1
 }
 
-func mainWithResult() (bool, error) {
-	flag.Parse()
-	if *printVersion {
-		buildinfo.PrintVersion()
-		return true, nil
-	}
-
-	var conf config.CrawlConfig
-	if err := readConfig(&conf); err != nil {
-		return false, err
-	}
-
-	r, err := crawler.Execute(&conf)
-	if err != nil {
-		return false, err
-	}
-
-	if err := writeReport(r); err != nil {
-		return false, err
-	}
-
-	return r.IsSuccessful(), nil
-}
-
-func readConfig(config *config.CrawlConfig) error {
-	if *configPath == "STDIN" || *configPath == "" || *configPath == "-" {
+func readConfig(config *config.CrawlConfig, configPath string) error {
+	if isSTDIN(configPath) {
 		return config.FromSTDIN()
 	}
-	return config.FromFile(*configPath)
+	return config.FromFile(configPath)
 }
 
-func writeReport(r *report.Report) error {
+func isSTDIN(path string) bool {
+	return path == "STDIN" || path == "" || path == "-"
+}
+
+func isSTDOUT(path string) bool {
+	return path == "STDOUT" || path == "" || path == "-"
+}
+
+func formatReport(ctx climax.Context) int {
+	inputPath, _ := ctx.Get("input")
+	outputPath, _ := ctx.Get("output")
+	reportFormat, ok := ctx.Get("format")
+	if !ok {
+		reportFormat = "ascii"
+	}
+
+	r, err := readReport(inputPath)
+	if err != nil {
+		log.Printf("failed to read report JSON: %s", err)
+		return 1
+	}
+	if err := writeReport(r, outputPath, reportFormat); err != nil {
+		log.Printf("failed to write report: %s", err)
+	}
+	return 0
+}
+
+func readReport(inputPath string) (*report.Report, error) {
+	var r report.Report
+	var reader io.Reader
+	if isSTDIN(inputPath) {
+		reader = os.Stdin
+	} else {
+		file, err := os.Open(inputPath)
+		if err != nil {
+			return nil, err
+		}
+		defer func() {
+			err := file.Close()
+			if err != nil {
+				log.Printf("failed to close input file: %s", err)
+			}
+		}()
+		reader = file
+	}
+
+	bufReader := bufio.NewReader(reader)
+	return &r, r.ReadFromJSON(bufReader)
+}
+
+func writeReport(r *report.Report, outputPath, reportFormat string) error {
 	var writer io.Writer
-	if *outputPath == "STDOUT" || *outputPath == "" || *outputPath == "-" {
+	if isSTDOUT(outputPath) {
 		writer = os.Stdout
 	} else {
-		file, err := os.Create(*outputPath)
+		file, err := os.Create(outputPath)
 		if err != nil {
 			return err
 		}
 		defer func() {
-			err = file.Close()
+			err := file.Close()
 			if err != nil {
 				log.Printf("failed to close output file: %s", err)
 			}
@@ -80,10 +212,8 @@ func writeReport(r *report.Report) error {
 	}
 
 	bufWriter := bufio.NewWriter(writer)
-
-	if err := format.ByType(*reportFormat, r, bufWriter); err != nil {
+	if err := format.ByType(reportFormat, r, bufWriter); err != nil {
 		return err
 	}
-
 	return bufWriter.Flush()
 }

--- a/lukki.go
+++ b/lukki.go
@@ -37,7 +37,7 @@ func mainWithResult() (bool, error) {
 		return true, nil
 	}
 
-	var conf config.Config
+	var conf config.CrawlConfig
 	if err := readConfig(&conf); err != nil {
 		return false, err
 	}
@@ -54,7 +54,7 @@ func mainWithResult() (bool, error) {
 	return r.IsSuccessful(), nil
 }
 
-func readConfig(config *config.Config) error {
+func readConfig(config *config.CrawlConfig) error {
 	if *configPath == "STDIN" || *configPath == "" || *configPath == "-" {
 		return config.FromSTDIN()
 	}

--- a/lukki.go
+++ b/lukki.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bufio"
-	"fmt"
 	"github.com/Lepovirta/lukki/config"
 	"github.com/Lepovirta/lukki/crawler"
 	"github.com/Lepovirta/lukki/format"
@@ -80,8 +79,15 @@ func main() {
 				Name:     "format",
 				Short:    "f",
 				Usage:    `--format=ascii`,
-				Help:     fmt.Sprintf("Report format (choices: json, ascii) (default: ascii)"),
+				Help:     "Report format (choices: json, ascii) (default: ascii)",
 				Variable: true,
+			},
+			{
+				Name:     "use-report-exit-code",
+				Short:    "e",
+				Usage:    `--use-report-exit-code`,
+				Help:     "Use report status as the exit code.",
+				Variable: false,
 			},
 		},
 		Examples: []climax.Example{
@@ -92,6 +98,14 @@ func main() {
 			{
 				Usecase:     "--format=ascii",
 				Description: `Read report from STDIN, write report to STDOUT in ASCII format`,
+			},
+			{
+				Usecase:     "--format=ascii --use-report-exit-code",
+				Description: `Format in ASCII and use the report status as the exit code`,
+			},
+			{
+				Usecase:     "--use-report-exit-code",
+				Description: `Check if the reported test was successful or failed`,
 			},
 		},
 		Handle: formatReport,
@@ -158,6 +172,7 @@ func formatReport(ctx climax.Context) int {
 	if !ok {
 		reportFormat = "ascii"
 	}
+	useReportExitCode := ctx.Is("use-report-exit-code")
 
 	r, err := readReport(inputPath)
 	if err != nil {
@@ -166,6 +181,10 @@ func formatReport(ctx climax.Context) int {
 	}
 	if err := writeReport(r, outputPath, reportFormat); err != nil {
 		log.Printf("failed to write report: %s", err)
+	}
+
+	if useReportExitCode && r.IsFailed() {
+		return 1
 	}
 	return 0
 }

--- a/report/report.go
+++ b/report/report.go
@@ -1,7 +1,9 @@
 package report
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"time"
 )
 
@@ -11,6 +13,10 @@ type Report struct {
 	Resources      []*Resource      `json:"resources"`
 	FailedRequests []*FailedRequest `json:"failedRequests"`
 	Errors         []string         `json:"errors"`
+}
+
+func (r *Report) ReadFromJSON(in io.Reader) error {
+	return json.NewDecoder(in).Decode(r)
 }
 
 func (r *Report) IsSuccessful() bool {


### PR DESCRIPTION
Test and report have separate sub-commands. This allows you to reformat
a JSON report into ASCII without running the test again. This is also
why the default output format for test is JSON.

Sub-command parameter handling is done using tucnak/climax library.

Closes #53